### PR TITLE
fix: merge DEFAULT dictionary with selected locale for complete extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,16 @@ Original repository (upstream): fresh132/Miz-edit-program
 Proceed.
 
 Run timestamp: 2025-12-22T17:25:06.087Z
+
+---
+
+Issue to solve: https://github.com/fresh132/Miz-edit-program/issues/50
+Your prepared branch: issue-50-fcae03a1e5a4
+Your prepared working directory: /tmp/gh-issue-solver-1767114880843
+Your forked repository: konard/fresh132-Miz-edit-program
+Original repository (upstream): fresh132/Miz-edit-program
+
+Proceed.
+
+
+Run timestamp: 2025-12-30T17:14:46.499Z

--- a/experiments/test-issue-50-locale-extraction.js
+++ b/experiments/test-issue-50-locale-extraction.js
@@ -1,0 +1,203 @@
+/**
+ * Test script for Issue #50: Import bug with locale switching
+ * Tests that locale selection properly extracts all data from the selected locale
+ *
+ * Issue description:
+ * - When importing a corrected file, not all data is extracted
+ * - When selecting locale "default" or "ru", it doesn't change properly
+ * - When selecting "ru" locale, only 200+ data items are extracted
+ * - When selecting "default" locale, only 500+ data items are extracted
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load dependencies
+const JSZip = require('jszip');
+const MizParser = require('../src/miz-parser.js');
+
+async function runTests() {
+    console.log('=== Issue #50: Import Bug with Locale Switching ===\n');
+
+    // First, create a test .miz file with both DEFAULT and RU locales
+    console.log('Creating test .miz with multiple locales...\n');
+
+    const zip = new JSZip();
+
+    // Create mission file with briefings
+    const missionContent = `
+mission = {
+    ["sortie"] = "Test Mission",
+    ["descriptionText"] = "DictKey_descriptionText_1",
+    ["descriptionBlueTask"] = "DictKey_descriptionBlueTask_1",
+    ["descriptionRedTask"] = "DictKey_descriptionRedTask_1",
+    ["coalition"] = {
+        ["blue"] = {},
+        ["red"] = {}
+    },
+    ["trig"] = {
+        ["actions"] = {}
+    },
+    ["trigrules"] = {}
+}
+`;
+    zip.file('mission', missionContent);
+
+    // Create DEFAULT dictionary with many entries
+    const defaultDictEntries = [];
+    // Add description entries
+    defaultDictEntries.push(`    ["DictKey_descriptionText_1"] = "This is the mission description in English"`);
+    defaultDictEntries.push(`    ["DictKey_descriptionBlueTask_1"] = "Blue task description in English"`);
+    defaultDictEntries.push(`    ["DictKey_descriptionRedTask_1"] = "Red task description in English"`);
+
+    // Add ActionText entries (simulating 500+ entries)
+    for (let i = 1; i <= 50; i++) {
+        defaultDictEntries.push(`    ["DictKey_ActionText_${i}"] = "Trigger message ${i} in English"`);
+    }
+
+    // Add Radio entries
+    for (let i = 1; i <= 30; i++) {
+        defaultDictEntries.push(`    ["DictKey_ActionRadioText_${i}"] = "Radio message ${i} in English"`);
+    }
+
+    const defaultDictContent = `dictionary = {\n${defaultDictEntries.join(',\n')}\n}`;
+    zip.file('l10n/DEFAULT/dictionary', defaultDictContent);
+
+    // Create RU dictionary with FEWER entries (simulating the bug scenario)
+    const ruDictEntries = [];
+    // Add description entries
+    ruDictEntries.push(`    ["DictKey_descriptionText_1"] = "Описание миссии на русском"`);
+    ruDictEntries.push(`    ["DictKey_descriptionBlueTask_1"] = "Описание задачи синих на русском"`);
+    ruDictEntries.push(`    ["DictKey_descriptionRedTask_1"] = "Описание задачи красных на русском"`);
+
+    // Add ActionText entries (simulating only 20 entries instead of 50)
+    for (let i = 1; i <= 20; i++) {
+        ruDictEntries.push(`    ["DictKey_ActionText_${i}"] = "Сообщение триггера ${i} на русском"`);
+    }
+
+    // Add Radio entries (simulating only 10 entries instead of 30)
+    for (let i = 1; i <= 10; i++) {
+        ruDictEntries.push(`    ["DictKey_ActionRadioText_${i}"] = "Радиосообщение ${i} на русском"`);
+    }
+
+    const ruDictContent = `dictionary = {\n${ruDictEntries.join(',\n')}\n}`;
+    zip.file('l10n/RU/dictionary', ruDictContent);
+
+    // Generate .miz buffer
+    const mizBuffer = await zip.generateAsync({ type: 'arraybuffer' });
+
+    // Test 1: Parse the .miz file
+    console.log('Test 1: Parse .miz file and check available locales');
+    const parsedData = await MizParser.parse(mizBuffer);
+    console.log('  - Locales found:', parsedData.availableLocales);
+    console.log('  - DEFAULT dictionary entries:', Object.keys(parsedData.dictionaries['DEFAULT'] || {}).length);
+    console.log('  - RU dictionary entries:', Object.keys(parsedData.dictionaries['RU'] || {}).length);
+    console.log('  ✓ PASS\n');
+
+    // Test 2: Extract with DEFAULT locale
+    console.log('Test 2: Extract text with DEFAULT locale');
+    const extractedDefault = MizParser.extractText(parsedData, {
+        mode: 'auto',
+        preferredLocale: 'DEFAULT'
+    });
+    console.log('  - Locale used:', extractedDefault.locale);
+    console.log('  - Briefings:', extractedDefault.extracted.briefings?.length || 0);
+    console.log('  - Triggers:', extractedDefault.extracted.triggers?.length || 0);
+    console.log('  - Radio:', extractedDefault.extracted.radio?.length || 0);
+    console.log('  - Total strings:', extractedDefault.stats.totalStrings);
+
+    // Check first trigger text to verify locale
+    if (extractedDefault.extracted.triggers?.length > 0) {
+        console.log('  - First trigger text:', extractedDefault.extracted.triggers[0].text.substring(0, 50));
+    }
+    console.log('  ✓ PASS\n');
+
+    // Test 3: Extract with RU locale
+    console.log('Test 3: Extract text with RU locale');
+    const extractedRU = MizParser.extractText(parsedData, {
+        mode: 'auto',
+        preferredLocale: 'RU'
+    });
+    console.log('  - Locale used:', extractedRU.locale);
+    console.log('  - Briefings:', extractedRU.extracted.briefings?.length || 0);
+    console.log('  - Triggers:', extractedRU.extracted.triggers?.length || 0);
+    console.log('  - Radio:', extractedRU.extracted.radio?.length || 0);
+    console.log('  - Total strings:', extractedRU.stats.totalStrings);
+
+    // Check first trigger text to verify locale
+    if (extractedRU.extracted.triggers?.length > 0) {
+        console.log('  - First trigger text:', extractedRU.extracted.triggers[0].text.substring(0, 50));
+    }
+    console.log('');
+
+    // Test 4: Compare extraction counts
+    console.log('Test 4: Compare extraction counts between locales');
+    const defaultCount = extractedDefault.stats.totalStrings;
+    const ruCount = extractedRU.stats.totalStrings;
+    console.log(`  - DEFAULT total: ${defaultCount}`);
+    console.log(`  - RU total: ${ruCount}`);
+    console.log(`  - Difference: ${defaultCount - ruCount}`);
+
+    if (defaultCount !== ruCount) {
+        console.log('  ⚠️ WARNING: Different number of entries extracted for different locales');
+        console.log('  This is the bug described in issue #50!');
+        console.log('  Expected: Both locales should extract ALL keys, using fallback for missing translations');
+    } else {
+        console.log('  ✓ PASS - Same number of entries for both locales');
+    }
+    console.log('');
+
+    // Test 5: Verify that RU locale extraction doesn't change when selecting it
+    console.log('Test 5: Verify locale selection actually changes the output');
+
+    // Extract multiple times with different locales
+    const extract1 = MizParser.extractText(parsedData, { preferredLocale: 'DEFAULT' });
+    const extract2 = MizParser.extractText(parsedData, { preferredLocale: 'RU' });
+    const extract3 = MizParser.extractText(parsedData, { preferredLocale: 'DEFAULT' }); // Switch back
+
+    console.log('  - First DEFAULT extraction locale:', extract1.locale);
+    console.log('  - RU extraction locale:', extract2.locale);
+    console.log('  - Second DEFAULT extraction locale:', extract3.locale);
+
+    if (extract1.locale === 'DEFAULT' && extract2.locale === 'RU' && extract3.locale === 'DEFAULT') {
+        console.log('  ✓ PASS - Locale switching works correctly');
+    } else {
+        console.log('  ✗ FAIL - Locale switching does not work as expected');
+    }
+    console.log('');
+
+    // Test 6: Check if entries in DEFAULT but not in RU are being extracted
+    console.log('Test 6: Check for missing entries when switching to RU locale');
+
+    // Get all ActionText keys from DEFAULT
+    const defaultActionTextKeys = Object.keys(parsedData.dictionaries['DEFAULT'])
+        .filter(k => k.startsWith('DictKey_ActionText_'));
+
+    // Get all ActionText keys from RU
+    const ruActionTextKeys = Object.keys(parsedData.dictionaries['RU'] || {})
+        .filter(k => k.startsWith('DictKey_ActionText_'));
+
+    console.log(`  - DEFAULT ActionText keys: ${defaultActionTextKeys.length}`);
+    console.log(`  - RU ActionText keys: ${ruActionTextKeys.length}`);
+    console.log(`  - Missing in RU: ${defaultActionTextKeys.length - ruActionTextKeys.length}`);
+
+    // Find which keys are missing
+    const missingKeys = defaultActionTextKeys.filter(k => !ruActionTextKeys.includes(k));
+    if (missingKeys.length > 0) {
+        console.log(`  - First 5 missing keys: ${missingKeys.slice(0, 5).join(', ')}`);
+        console.log('  ⚠️ These entries will NOT be extracted when RU locale is selected!');
+        console.log('  SOLUTION: Fallback to DEFAULT dictionary for missing keys');
+    }
+    console.log('');
+
+    console.log('=== Test Summary ===');
+    console.log('The issue is that when a locale (like RU) has fewer dictionary entries');
+    console.log('than DEFAULT, the extraction only uses entries from the selected locale.');
+    console.log('This causes fewer items to be extracted when switching locales.');
+    console.log('');
+    console.log('PROPOSED FIX: When extracting from dictionary, merge DEFAULT and');
+    console.log('selected locale dictionaries, using selected locale values when');
+    console.log('available, and falling back to DEFAULT for missing keys.');
+}
+
+runTests().catch(console.error);

--- a/experiments/test-issue-50-verify-fix.js
+++ b/experiments/test-issue-50-verify-fix.js
@@ -1,0 +1,137 @@
+/**
+ * Test script for Issue #50: Verify the fix for import bug with locale switching
+ * Verifies that:
+ * 1. When RU locale is selected, RU translations are used for keys that exist in RU
+ * 2. For keys that only exist in DEFAULT, DEFAULT values are used as fallback
+ * 3. Total count of extracted items is the same for all locales
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load dependencies
+const JSZip = require('jszip');
+const MizParser = require('../src/miz-parser.js');
+
+async function runTests() {
+    console.log('=== Issue #50: Verify Fix for Locale Switching ===\n');
+
+    // Create test .miz file with both DEFAULT and RU locales
+    const zip = new JSZip();
+
+    const missionContent = `
+mission = {
+    ["sortie"] = "Test Mission",
+    ["descriptionText"] = "DictKey_descriptionText_1",
+    ["coalition"] = {},
+    ["trig"] = {},
+    ["trigrules"] = {}
+}
+`;
+    zip.file('mission', missionContent);
+
+    // DEFAULT dictionary with entries for ActionText_1 through ActionText_10
+    const defaultDictEntries = [
+        `    ["DictKey_descriptionText_1"] = "English description"`,
+        // Entries 1-5 will be in both DEFAULT and RU
+        `    ["DictKey_ActionText_1"] = "English trigger 1"`,
+        `    ["DictKey_ActionText_2"] = "English trigger 2"`,
+        `    ["DictKey_ActionText_3"] = "English trigger 3"`,
+        `    ["DictKey_ActionText_4"] = "English trigger 4"`,
+        `    ["DictKey_ActionText_5"] = "English trigger 5"`,
+        // Entries 6-10 will only be in DEFAULT (fallback test)
+        `    ["DictKey_ActionText_6"] = "English trigger 6"`,
+        `    ["DictKey_ActionText_7"] = "English trigger 7"`,
+        `    ["DictKey_ActionText_8"] = "English trigger 8"`,
+        `    ["DictKey_ActionText_9"] = "English trigger 9"`,
+        `    ["DictKey_ActionText_10"] = "English trigger 10"`
+    ];
+    const defaultDictContent = `dictionary = {\n${defaultDictEntries.join(',\n')}\n}`;
+    zip.file('l10n/DEFAULT/dictionary', defaultDictContent);
+
+    // RU dictionary with only entries 1-5 (with Russian translations)
+    const ruDictEntries = [
+        `    ["DictKey_descriptionText_1"] = "Описание на русском"`,
+        `    ["DictKey_ActionText_1"] = "Русский триггер 1"`,
+        `    ["DictKey_ActionText_2"] = "Русский триггер 2"`,
+        `    ["DictKey_ActionText_3"] = "Русский триггер 3"`,
+        `    ["DictKey_ActionText_4"] = "Русский триггер 4"`,
+        `    ["DictKey_ActionText_5"] = "Русский триггер 5"`
+    ];
+    const ruDictContent = `dictionary = {\n${ruDictEntries.join(',\n')}\n}`;
+    zip.file('l10n/RU/dictionary', ruDictContent);
+
+    const mizBuffer = await zip.generateAsync({ type: 'arraybuffer' });
+    const parsedData = await MizParser.parse(mizBuffer);
+
+    console.log('Test 1: Verify total counts are equal for all locales');
+    const extractedDefault = MizParser.extractText(parsedData, { preferredLocale: 'DEFAULT' });
+    const extractedRU = MizParser.extractText(parsedData, { preferredLocale: 'RU' });
+
+    console.log(`  DEFAULT: ${extractedDefault.stats.totalStrings} entries`);
+    console.log(`  RU: ${extractedRU.stats.totalStrings} entries`);
+
+    if (extractedDefault.stats.totalStrings === extractedRU.stats.totalStrings) {
+        console.log('  ✓ PASS - Same number of entries for both locales\n');
+    } else {
+        console.log('  ✗ FAIL - Different number of entries!\n');
+        process.exit(1);
+    }
+
+    console.log('Test 2: Verify RU translations are used when available');
+    const ruTriggers = extractedRU.extracted.triggers || [];
+    const ruTrigger1 = ruTriggers.find(t => t.context === 'DictKey_ActionText_1');
+
+    if (ruTrigger1 && ruTrigger1.text === 'Русский триггер 1') {
+        console.log(`  RU trigger 1: "${ruTrigger1.text}"`);
+        console.log('  ✓ PASS - RU translation is used\n');
+    } else {
+        console.log(`  RU trigger 1: "${ruTrigger1?.text || 'NOT FOUND'}"`);
+        console.log('  ✗ FAIL - RU translation not used!\n');
+        process.exit(1);
+    }
+
+    console.log('Test 3: Verify DEFAULT fallback for missing RU entries');
+    const ruTrigger6 = ruTriggers.find(t => t.context === 'DictKey_ActionText_6');
+
+    if (ruTrigger6 && ruTrigger6.text === 'English trigger 6') {
+        console.log(`  RU trigger 6 (fallback): "${ruTrigger6.text}"`);
+        console.log('  ✓ PASS - DEFAULT fallback is used for missing entries\n');
+    } else {
+        console.log(`  RU trigger 6: "${ruTrigger6?.text || 'NOT FOUND'}"`);
+        console.log('  ✗ FAIL - DEFAULT fallback not working!\n');
+        process.exit(1);
+    }
+
+    console.log('Test 4: Verify all 10 triggers are extracted for RU locale');
+    if (ruTriggers.length === 10) {
+        console.log(`  Total triggers for RU: ${ruTriggers.length}`);
+        console.log('  ✓ PASS - All 10 triggers extracted\n');
+    } else {
+        console.log(`  Total triggers for RU: ${ruTriggers.length}`);
+        console.log('  ✗ FAIL - Expected 10 triggers!\n');
+        process.exit(1);
+    }
+
+    console.log('Test 5: Verify locale is correctly reported');
+    console.log(`  DEFAULT extraction locale: ${extractedDefault.locale}`);
+    console.log(`  RU extraction locale: ${extractedRU.locale}`);
+
+    if (extractedDefault.locale === 'DEFAULT' && extractedRU.locale === 'RU') {
+        console.log('  ✓ PASS - Locales correctly reported\n');
+    } else {
+        console.log('  ✗ FAIL - Locales not correctly reported!\n');
+        process.exit(1);
+    }
+
+    console.log('=== All Tests Passed! ===');
+    console.log('The fix for Issue #50 is working correctly:');
+    console.log('- RU translations are used when available');
+    console.log('- DEFAULT values are used as fallback for missing entries');
+    console.log('- Total counts are equal for all locales');
+}
+
+runTests().catch(e => {
+    console.error('Test failed:', e.message);
+    process.exit(1);
+});

--- a/experiments/test-issue-50-with-sample.js
+++ b/experiments/test-issue-50-with-sample.js
@@ -1,0 +1,67 @@
+/**
+ * Test Issue #50 fix with the sample_mission.miz file
+ * This file has both DEFAULT and RU dictionaries with different contents
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MizParser = require('../src/miz-parser.js');
+
+async function runTest() {
+    console.log('=== Issue #50: Test with sample_mission.miz ===\n');
+
+    const sampleMizPath = path.join(__dirname, '..', 'samples', 'sample_mission.miz');
+    if (!fs.existsSync(sampleMizPath)) {
+        console.error('Sample .miz file not found. Run: node samples/create-miz-archive.js');
+        process.exit(1);
+    }
+
+    const mizBuffer = fs.readFileSync(sampleMizPath);
+    const parsedData = await MizParser.parse(mizBuffer);
+
+    console.log('Available locales:', parsedData.availableLocales);
+    console.log('DEFAULT dictionary keys:', Object.keys(parsedData.dictionaries['DEFAULT'] || {}).length);
+    console.log('RU dictionary keys:', Object.keys(parsedData.dictionaries['RU'] || {}).length);
+    console.log('');
+
+    // Extract with DEFAULT
+    const extractedDefault = MizParser.extractText(parsedData, { preferredLocale: 'DEFAULT' });
+    console.log('Extraction with DEFAULT locale:');
+    console.log('  Locale used:', extractedDefault.locale);
+    console.log('  Briefings:', extractedDefault.extracted.briefings?.length || 0);
+    console.log('  Triggers:', extractedDefault.extracted.triggers?.length || 0);
+    console.log('  Radio:', extractedDefault.extracted.radio?.length || 0);
+    console.log('  Total:', extractedDefault.stats.totalStrings);
+    console.log('');
+
+    // Extract with RU
+    const extractedRU = MizParser.extractText(parsedData, { preferredLocale: 'RU' });
+    console.log('Extraction with RU locale:');
+    console.log('  Locale used:', extractedRU.locale);
+    console.log('  Briefings:', extractedRU.extracted.briefings?.length || 0);
+    console.log('  Triggers:', extractedRU.extracted.triggers?.length || 0);
+    console.log('  Radio:', extractedRU.extracted.radio?.length || 0);
+    console.log('  Total:', extractedRU.stats.totalStrings);
+    console.log('');
+
+    // Verify counts match
+    if (extractedDefault.stats.totalStrings === extractedRU.stats.totalStrings) {
+        console.log('✓ PASS - Both locales extract the same number of strings');
+    } else {
+        console.log('✗ FAIL - Different number of strings extracted!');
+        console.log(`  DEFAULT: ${extractedDefault.stats.totalStrings}`);
+        console.log(`  RU: ${extractedRU.stats.totalStrings}`);
+        process.exit(1);
+    }
+
+    // Show sample texts to verify translations are being used
+    if (extractedRU.extracted.triggers?.length > 0) {
+        console.log('');
+        console.log('Sample RU trigger text:', extractedRU.extracted.triggers[0].text.substring(0, 80) + '...');
+    }
+
+    console.log('\n=== Test Complete ===');
+}
+
+runTest().catch(console.error);

--- a/src/miz-parser.js
+++ b/src/miz-parser.js
@@ -178,16 +178,27 @@ var MizParser = {
         };
 
         // Select the dictionary to use
-        let dictionary = parsedData.dictionaries[preferredLocale];
-        if (!dictionary && preferredLocale !== 'DEFAULT') {
-            dictionary = parsedData.dictionaries['DEFAULT'];
+        // Issue #50: Merge DEFAULT dictionary with selected locale dictionary
+        // This ensures ALL entries are extracted, using selected locale values when available
+        // and falling back to DEFAULT for missing keys
+        let dictionary = {};
+        const defaultDict = parsedData.dictionaries['DEFAULT'] || {};
+        const localeDict = parsedData.dictionaries[preferredLocale] || {};
+
+        // Start with all entries from DEFAULT
+        Object.assign(dictionary, defaultDict);
+
+        // Override with entries from selected locale (if not DEFAULT)
+        if (preferredLocale !== 'DEFAULT' && Object.keys(localeDict).length > 0) {
+            Object.assign(dictionary, localeDict);
+            result.locale = preferredLocale;
+        } else if (Object.keys(defaultDict).length > 0) {
             result.locale = 'DEFAULT';
-        }
-        if (!dictionary) {
-            // Use first available dictionary
+        } else {
+            // Use first available dictionary as fallback
             const firstLocale = parsedData.availableLocales[0];
             if (firstLocale) {
-                dictionary = parsedData.dictionaries[firstLocale];
+                dictionary = parsedData.dictionaries[firstLocale] || {};
                 result.locale = firstLocale;
             }
         }


### PR DESCRIPTION
## 📋 Issue Reference
Fixes fresh132/Miz-edit-program#50

## 🔍 Problem
When importing a corrected file and selecting locale (DEFAULT or RU), not all data was being extracted:
- When selecting "RU" locale, only 200+ data items were extracted
- When selecting "DEFAULT" locale, only 500+ items were extracted
- The locale selection didn't properly switch between locales

## 🔧 Root Cause
The `extractText` function in `miz-parser.js` was only using entries from the selected locale's dictionary. When a locale (like RU) had fewer dictionary entries than DEFAULT, the extraction would miss entries that only existed in DEFAULT.

## ✅ Solution
Modified the dictionary selection logic to merge DEFAULT dictionary with the selected locale dictionary:

1. **Start with all entries from DEFAULT dictionary**
2. **Override with entries from selected locale** - when available, use the translated values
3. **Fallback mechanism** - for keys that only exist in DEFAULT, those values are used as fallback

This ensures ALL entries are extracted regardless of which locale is selected, using:
- Translated values when they exist in the selected locale
- DEFAULT values as fallback when translations are missing

## 📝 Changes
- `src/miz-parser.js`: Modified `extractText` function to merge dictionaries with fallback

## 🧪 Testing
Added test scripts to verify the fix:
- `experiments/test-issue-50-locale-extraction.js` - Reproduces the original bug and verifies fix
- `experiments/test-issue-50-verify-fix.js` - Verifies RU translations are used when available
- `experiments/test-issue-50-with-sample.js` - Tests with the sample_mission.miz file

All tests pass:
- ✅ Both locales extract the same number of entries
- ✅ RU translations are used when available
- ✅ DEFAULT values are used as fallback for missing entries
- ✅ Locale switching works correctly

---
*🤖 Generated with [Claude Code](https://claude.com/claude-code)*